### PR TITLE
Resolves bug with duplicate nav/buttons

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -23,6 +23,7 @@ const signUpSuccess = function (data) {
 }
 
 const signedInNav = function () {
+  $('.account-nav').html('')
   const showSignedInNavHtml = showSignedInNavTemplate()
   $('.account-nav').append(showSignedInNavHtml)
 }
@@ -38,6 +39,7 @@ const surveyContent = function () {
 }
 
 const userActions = function () {
+  $('.user-actions').html('')
   const showUserActionsHtml = loadUserActionsTemplate()
   $('.user-actions').append(showUserActionsHtml)
 }

--- a/assets/scripts/survey/ui.js
+++ b/assets/scripts/survey/ui.js
@@ -30,7 +30,6 @@ const loadSurveyForm = function () {
 }
 
 const rButton = function () {
-  $('.refresh-survey').html('')
   const showRButtonHtml = loadRefreshTemplate()
   if ($('.refresh-survey').html('')) {
     $('.refresh-survey').append(showRButtonHtml)
@@ -38,7 +37,6 @@ const rButton = function () {
 }
 
 const crButton = function () {
-  $('.create-survey').html('')
   const showCrButtonHtml = loadCreateButtonTemplate()
   if ($('.create-survey').html('')) {
     $('.create-survey').append(showCrButtonHtml)


### PR DESCRIPTION
Clears `signedInNav` and `userActions` each successful sign in to make
sure the templates don't appear as loaded more than once if the sign-in
action is submitted multiple time before the server responds