### PR TITLE
Adds throttle to submit survey/submission

### DIFF
--- a/assets/scripts/submission/events.js
+++ b/assets/scripts/submission/events.js
@@ -6,6 +6,17 @@ const ui = require('./ui')
 const survApi = require('../survey/api')
 const survEvents = require('../survey/events')
 
+const throttle = function (func, interval) {
+  let lastCall = 0
+  return function () {
+    const now = Date.now()
+    if (lastCall + interval < now) {
+      lastCall = now
+      return func.apply(this, arguments)
+    }
+  }
+}
+
 const onCreateSubmission = function (event) {
   event.preventDefault()
   const data = getFormFields(this)
@@ -27,7 +38,7 @@ const onTakeSurvey = function (event) {
 }
 
 const addHandlers = function () {
-  $('.main').on('submit', '#create-submission-form', onCreateSubmission)
+  $('.main').on('submit', '#create-submission-form', throttle(onCreateSubmission, 1000))
   $('.main').on('click', '.take-survey', onTakeSurvey)
 }
 

--- a/assets/scripts/survey/events.js
+++ b/assets/scripts/survey/events.js
@@ -5,6 +5,17 @@ const api = require(`./api`)
 const ui = require('./ui')
 const authUi = require('../auth/ui')
 
+const throttle = function (func, interval) {
+  let lastCall = 0
+  return function () {
+    const now = Date.now()
+    if (lastCall + interval < now) {
+      lastCall = now
+      return func.apply(this, arguments)
+    }
+  }
+}
+
 const onCreateSurvey = function (event) {
   const data = getFormFields(this)
   event.preventDefault()
@@ -67,7 +78,7 @@ const onLoadSurveyForm = function () {
 
 const addHandlers = function () {
   $('.main').on('click', '.close-form', onGetAllSurveys)
-  $('.user-actions').on('click', '.create-survey-button', onLoadSurveyForm)
+  $('.user-actions').on('click', '.create-survey-button', throttle(onLoadSurveyForm, 1000))
   $('.user-actions').on('click', '.refresh-survey-button', onGetAllSurveys)
   $('.test-survey-crud').on('submit', '#get-survey-form', onGetASurvey)
   $('.main').on('submit', '#update-survey-form', onUpdateSurvey)


### PR DESCRIPTION
When hitting enter, or clicking confirm, more than once before server
responded the action would successfully complete each time and result in
multiple surveys or multiple submissions respectively.

This adds a throttle to those actions so it cannot run more than once
per second. Thanks to @skinnybuff for pointing this out